### PR TITLE
添加检查description是否为空

### DIFF
--- a/plugins/Generic/plugin-sync-configuration-gists.js
+++ b/plugins/Generic/plugin-sync-configuration-gists.js
@@ -157,7 +157,9 @@ const getPrefix = () => {
 
 const filterList = (list) => {
   const prefix = getPrefix()
-  return list.filter((v) => v.description.startsWith(prefix)).map((v) => ({ label: v.description, value: v.id }))
+  return list
+  .filter((v) => v.description && v.description.startsWith(prefix))
+  .map((v) => ({ label: v.description, value: v.id }))
 }
 
 /**


### PR DESCRIPTION
添加检查description是否为空，避免调用startswith报错；
vscode中的同步配置也会使用gist作同步，但是vscode创建的gist没有description，会导致在filterList中检查前缀报错