### PR TITLE
Update plugin-sync-configuration-webdav.js

### DIFF
--- a/plugins/Generic/plugin-sync-configuration-webdav.js
+++ b/plugins/Generic/plugin-sync-configuration-webdav.js
@@ -282,9 +282,11 @@ class WebDAV {
     for (let i = 0; i < responses.length; i++) {
       const isCollection = responses[i].getElementsByTagNameNS('DAV:', 'resourcetype')[0]?.getElementsByTagNameNS('DAV:', 'collection').length > 0
       if (isCollection) continue
+      const href = getTextContent(responses[i], 'D:href')
+      const displayname = getTextContent(responses[i], 'D:displayname') || href.replace(Plugin.DataPath + '/', '')
       list.push({
-        href: getTextContent(responses[i], 'D:href'),
-        displayname: getTextContent(responses[i], 'D:displayname') || '',
+        href: href,
+        displayname:displayname,
         lastModified: getTextContent(responses[i], 'D:getlastmodified') || 'N/A',
         creationDate: getTextContent(responses[i], 'D:creationdate') || 'N/A'
       })


### PR DESCRIPTION
feat: 默认 displayname 使用 href 去除前缀后的内容

- 当响应中不存在 D:displayname 时，从 D:href 中剔除 Plugins.DataPath + '/' 前缀后，将剩余部分作为 displayname 值
- 保证文件列表展示时始终有合理的 displayname