### PR TITLE
improv: Always show the HTTP proxy toggle

### DIFF
--- a/plugins/GFS/plugin-share-profile-to-phone.js
+++ b/plugins/GFS/plugin-share-profile-to-phone.js
@@ -52,7 +52,7 @@ const Share = async (profile) => {
   else {
     // * 开启TUN
     let tun = profile.inbounds.find((v) => v.type === 'tun')
-    const mixed = profile.inbounds.find((v) => v.type === 'mixed')
+    let mixed = profile.inbounds.find((v) => v.type === 'mixed')
     const http = profile.inbounds.find((v) => v.type === 'http')
     if (!tun) {
       tun = {
@@ -75,7 +75,7 @@ const Share = async (profile) => {
     if (mixed) {
       tun.tun.platform = {
         http_proxy: {
-          enabled: false,
+          enabled: true,
           server: '127.0.0.1',
           server_port: mixed.mixed.listen.listen_port
         }
@@ -83,9 +83,31 @@ const Share = async (profile) => {
     } else if (http) {
       tun.tun.platform = {
         http_proxy: {
-          enabled: false,
+          enabled: true,
           server: '127.0.0.1',
           server_port: http.http.listen.listen_port
+        }
+      }
+    } else {
+      mixed = {
+        id: Plugins.sampleID(),
+        tag: 'mixed-in',
+        type: 'mixed',
+        enable: true,
+        mixed: {
+          listen: {
+            listen: '127.0.0.1',
+            listen_port: 20122
+          },
+          users: []
+        }
+      }
+      profile.inbounds.push(mixed)
+      tun.tun.platform = {
+        http_proxy: {
+          enabled: true,
+          server: '127.0.0.1',
+          server_port: mixed.mixed.listen.listen_port
         }
       }
     }


### PR DESCRIPTION
http_proxy.enabled 的实际作用为显示 HTTP 代理开关，默认为关闭状态，作为良性配置，可以始终启用