### PR TITLE
feat: 新增插件「扫码分享配置到手机CMFA」

### DIFF
--- a/plugins/GFC/plugin-share-config-qrcode.js
+++ b/plugins/GFC/plugin-share-config-qrcode.js
@@ -1,0 +1,270 @@
+const JS_FILE = 'https://cdn.jsdelivr.net/npm/qrcode/build/qrcode.js'
+const PATH = 'data/third/share-config-qrcode'
+
+/* 触发器 手动触发 */
+const onRun = async () => {
+  const profilesStore = Plugins.useProfilesStore()
+  if (profilesStore.profiles.length === 0) {
+    throw '请先创建一个配置'
+  }
+
+  let profile = null
+  if (profilesStore.profiles.length === 1) {
+    profile = profilesStore.profiles[0]
+  } else {
+    profile = await Plugins.picker.single(
+      '请选择要分享的配置',
+      profilesStore.profiles.map((v) => ({
+        label: v.name,
+        value: v
+      })),
+      [profilesStore.profiles[0]]
+    )
+  }
+
+  await share(Plugins.deepClone(profile))
+}
+
+const share = async (profile) => {
+  const port = (Plugin.Port && Plugin.Port !== 'undefined' && Plugin.Port !== '') ? Plugin.Port : '18963'
+  await loadDependence()
+
+  // 1. 启用 TUN（手机端必须）
+  profile.tunConfig.enable = true
+  profile.tunConfig.stack = 'Mixed'
+  profile.tunConfig['auto-route'] = true
+  profile.tunConfig['auto-detect-interface'] = true
+  profile.tunConfig['dns-hijack'] = ['any:53']
+  profile.tunConfig['strict-route'] = true
+
+  // 2. 替换本地规则集为远程规则集
+  const rulesetsStore = Plugins.useRulesetsStore()
+  for (const rule of profile.rulesConfig) {
+    if (rule.type !== 'RULE-SET' || !rule.enable) continue
+    if (rule['ruleset-type'] === 'file' && rule.payload) {
+      const ruleset = rulesetsStore.getRulesetById(rule.payload)
+      if (ruleset && ruleset.type === 'Http' && ruleset.url) {
+        rule['ruleset-type'] = 'http'
+        rule['ruleset-name'] = ruleset.name || rule.payload
+        rule['ruleset-format'] = ruleset.format || rule['ruleset-format']
+        rule['ruleset-behavior'] = ruleset.behavior || rule['ruleset-behavior']
+        rule.payload = ruleset.url
+      }
+    }
+  }
+
+  // 3. 生成 Mihomo 配置
+  const config = await Plugins.generateConfig(profile)
+
+  // 4. 消除 proxy-providers：全部内联节点，展开 use 引用
+  //    避免 http provider 与 inline proxies 重名冲突，确保配置完全自包含
+  const subscribesStore = Plugins.useSubscribesStore()
+  if (config['proxy-providers']) {
+    const existingNames = new Set((config.proxies || []).map((p) => p.name))
+
+    for (const [id, provider] of Object.entries(config['proxy-providers'])) {
+      // 读取该 provider 的节点列表
+      const sub = subscribesStore.getSubscribeById(id)
+      const subPath = sub ? sub.path : provider.path?.replace(/^\.\.\//, 'data/')
+      let providerProxyNames = []
+      if (subPath) {
+        try {
+          const content = await Plugins.ReadFile(subPath)
+          const parsed = Plugins.YAML.parse(content)
+          const proxies = parsed.proxies || []
+          // 内联不重复的节点
+          for (const proxy of proxies) {
+            if (!existingNames.has(proxy.name)) {
+              config.proxies = config.proxies || []
+              config.proxies.push(proxy)
+              existingNames.add(proxy.name)
+            }
+          }
+          providerProxyNames = proxies.map((p) => p.name)
+        } catch (e) {
+          console.warn(`无法读取订阅 ${id} 的缓存:`, e)
+        }
+      }
+
+      // 将引用此 provider 的 proxy-groups 的 use 展开为 proxies
+      for (const group of config['proxy-groups'] || []) {
+        if (group.use && group.use.includes(id)) {
+          group.use = group.use.filter((u) => u !== id)
+          if (group.use.length === 0) delete group.use
+          group.proxies = group.proxies || []
+          group.proxies.push(...providerProxyNames.filter((n) => !group.proxies.includes(n)))
+        }
+      }
+    }
+
+    delete config['proxy-providers']
+  }
+
+  // 5. 兜底：检查 rule-providers 中残留的 file 类型
+  if (config['rule-providers']) {
+    for (const [name, provider] of Object.entries(config['rule-providers'])) {
+      if (provider.type !== 'file') continue
+      const ruleset = rulesetsStore.rulesets.find((r) => r.name === name || r.id === name)
+      if (ruleset && ruleset.type === 'Http' && ruleset.url) {
+        provider.type = 'http'
+        provider.url = ruleset.url
+        provider.interval = 86400
+        delete provider.path
+      }
+    }
+  }
+
+  // 7. CMFA 只显示 GLOBAL 组引用的代理组，确保自定义组可见
+  const groups = config['proxy-groups'] || []
+  const globalGroup = groups.find((g) => g.name === 'GLOBAL')
+  if (globalGroup) {
+    const globalProxies = new Set(globalGroup.proxies || [])
+    for (const group of groups) {
+      if (group === globalGroup || group.hidden) continue
+      if (!globalProxies.has(group.name)) {
+        globalGroup.proxies = globalGroup.proxies || []
+        globalGroup.proxies.push(group.name)
+      }
+    }
+  }
+
+  // 8. 清理 PC 专属配置
+  delete config.secret
+  config['external-controller'] = '127.0.0.1:9090'
+  config['allow-lan'] = false
+
+  // 9. TUN 模式 DNS 引导：确保代理节点域名和 DNS 服务器域名能直连解析，避免循环依赖
+  if (config.dns) {
+    const bootstrapDNS = ['223.5.5.5', '8.8.8.8']
+    if (!config.dns['proxy-server-nameserver'] || config.dns['proxy-server-nameserver'].length === 0) {
+      config.dns['proxy-server-nameserver'] = bootstrapDNS
+    }
+    if (!config.dns['default-nameserver'] || config.dns['default-nameserver'].length === 0) {
+      config.dns['default-nameserver'] = bootstrapDNS
+    }
+  }
+
+
+  // 8. 获取本机局域网 IP 并启动 HTTP 服务
+  const ips = await getIPAddress()
+  if (ips.length === 0) throw '未找到局域网 IP 地址，请检查网络连接'
+
+  const configYaml = Plugins.YAML.stringify(config)
+
+  // DEBUG: 保存生成的配置供检查（调试时取消注释）
+  // await Plugins.WriteFile(PATH + '/debug-config.yaml', configYaml)
+
+  const urls = await Promise.all(
+    ips.map((ip) => {
+      const url = `http://${ip}:${port}`
+      return getQRCode(url, url)
+    })
+  )
+
+  const { close } = await Plugins.StartServer('0.0.0.0:' + port, Plugin.id, async (req, res) => {
+    res.end(200, { 'Content-Type': 'text/yaml; charset=utf-8' }, configYaml)
+  })
+
+  await Plugins.alert(
+    Plugin.name,
+    '### 注意事项：\n\n' +
+      ' - 请保证电脑和手机处于同一局域网内\n' +
+      ' - 请关闭电脑防火墙或放行端口 ' + port + '\n' +
+      ' - 如果 CMFA 无法通过深度链接导入，请复制链接在 CMFA 中手动添加\n' +
+      ' - 如果仍无法导入，请更换不同二维码尝试\n\n' +
+      '|分享链接|二维码|\n|-|-|\n' +
+      urls.map((item) => `|${item.url}|![](${item.qrcode})|`).join('\n'),
+    { type: 'markdown' }
+  )
+
+  close()
+}
+
+/* 触发器 安装 */
+const onInstall = async () => {
+  await Plugins.Download(JS_FILE, PATH + '/qrcode.min.js')
+  await Plugins.message.success('安装成功')
+  return 0
+}
+
+/* 触发器 卸载 */
+const onUninstall = async () => {
+  await Plugins.RemoveFile(PATH)
+  return 0
+}
+
+/**
+ * 动态引入 QRCode 依赖，不存在时自动下载
+ */
+async function loadDependence() {
+  if (window.QRCode) return
+
+  const filePath = PATH + '/qrcode.min.js'
+  let text = await Plugins.ignoredError(Plugins.ReadFile, filePath)
+
+  if (!text) {
+    const { id } = Plugins.message.info('正在下载二维码依赖...', 30000)
+    try {
+      await Plugins.Download(JS_FILE, filePath)
+      text = await Plugins.ReadFile(filePath)
+      Plugins.message.update(id, '依赖下载完成', 'success')
+      await Plugins.sleep(1000).then(() => Plugins.message.destroy(id))
+    } catch (error) {
+      Plugins.message.destroy(id)
+      throw '二维码依赖下载失败，请检查网络连接'
+    }
+  }
+
+  const script = document.createElement('script')
+  script.id = Plugin.id
+  script.text = text
+  document.body.appendChild(script)
+}
+
+/**
+ * 生成二维码 Data URL
+ */
+function getQRCode(rawUrl, content) {
+  return new Promise((resolve) => {
+    QRCode.toDataURL(content, { width: 256, margin: 2 }, (err, dataUrl) => {
+      resolve({ url: rawUrl, qrcode: dataUrl })
+    })
+  })
+}
+
+/**
+ * 判断是否为私有 IP
+ */
+function isPrivateIP(ip) {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return false
+  const first = parseInt(parts[0], 10)
+  const second = parseInt(parts[1], 10)
+  const fourth = parseInt(parts[3], 10)
+  if (first === 255 || fourth === 1 || fourth === 255) return false
+  if (first === 10) return true
+  if (first === 172 && second >= 16 && second <= 31) return true
+  if (first === 192 && second === 168) return true
+  return false
+}
+
+/**
+ * 获取本机局域网 IP 列表
+ */
+async function getIPAddress() {
+  const os = Plugins.useEnvStore().env.os
+  const cmd = { windows: 'ipconfig', linux: 'ip', darwin: 'ifconfig' }[os]
+  const arg = { windows: [], linux: ['a'], darwin: [] }[os]
+  const text = await Plugins.Exec(cmd, arg, { convert: os === 'windows' })
+  const ipv4Pattern = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g
+  let ips = text.match(ipv4Pattern) || []
+  ips = ips.filter((ip) => isPrivateIP(ip))
+
+  const getPriority = (ip) => {
+    if (ip.startsWith('192.')) return 0
+    if (ip.startsWith('10.')) return 1
+    if (ip.startsWith('172.')) return 2
+    return 3
+  }
+  return [...new Set(ips)].sort((a, b) => getPriority(a) - getPriority(b))
+}

--- a/plugins/gfc.json
+++ b/plugins/gfc.json
@@ -4,11 +4,18 @@
     "name": "链式代理支持",
     "version": "v1.0.3",
     "description": "可视化配置链式代理与生成配置时作用链式代理。",
-    "tags": ["实用工具", "功能扩展", "提升体验"],
+    "tags": [
+      "实用工具",
+      "功能扩展",
+      "提升体验"
+    ],
     "type": "Http",
     "url": "https://raw.githubusercontent.com/GUI-for-Cores/Plugin-Hub/main/plugins/GFC/plugin-proxy-chain-manager.js",
     "path": "data/plugins/plugin-proxy-chain-manager.js",
-    "triggers": ["on::manual", "on::generate"],
+    "triggers": [
+      "on::manual",
+      "on::generate"
+    ],
     "hasUI": true,
     "menus": {},
     "context": {
@@ -31,11 +38,16 @@
     "name": "一键添加规则集",
     "version": "v1.0.1",
     "description": "一键添加所有的规则集到你的列表，添加后你需要手动更新规则集来下载到本地，以便在配置文件中引用它们。",
-    "tags": ["提升体验", "功能扩展"],
+    "tags": [
+      "提升体验",
+      "功能扩展"
+    ],
     "type": "Http",
     "url": "https://raw.githubusercontent.com/GUI-for-Cores/Plugin-Hub/main/plugins/GFC/plugin-add-rulesets.js",
     "path": "data/plugins/plugin-add-rulesets.js",
-    "triggers": ["on::manual"],
+    "triggers": [
+      "on::manual"
+    ],
     "menus": {},
     "hasUI": false,
     "context": {
@@ -47,6 +59,49 @@
     },
     "status": 0,
     "configuration": [],
+    "disabled": false,
+    "install": false,
+    "installed": false
+  },
+  {
+    "id": "plugin-share-config-qrcode",
+    "name": "扫码分享配置到手机CMFA",
+    "version": "v1.0.0",
+    "description": "手机端CMFA(Clash Meta for Android)扫码即可一键导入完整Mihomo配置。电脑端启动局域网临时HTTP服务，自动完成手机适配：启用TUN模式、内联proxy-providers消除重名冲突、本地rule-providers转远程HTTP、补全GLOBAL代理组确保CMFA可见、设置proxy-server-nameserver避免DNS循环依赖。支持链式代理(dialer-proxy)、自定义代理组等完整配置透传。",
+    "tags": [
+      "实用工具",
+      "功能扩展",
+      "提升体验"
+    ],
+    "type": "Http",
+    "url": "https://raw.githubusercontent.com/GUI-for-Cores/Plugin-Hub/main/plugins/GFC/plugin-share-config-qrcode.js",
+    "path": "data/plugins/plugin-share-config-qrcode.js",
+    "triggers": [
+      "on::manual",
+      "on::install",
+      "on::uninstall"
+    ],
+    "hasUI": false,
+    "menus": {},
+    "context": {
+      "profiles": {},
+      "subscriptions": {},
+      "rulesets": {},
+      "plugins": {},
+      "scheduledtasks": {}
+    },
+    "status": 0,
+    "configuration": [
+      {
+        "id": "ID_qrshare_port",
+        "title": "HTTP 服务端口",
+        "description": "临时 HTTP 服务监听端口，用于手机获取配置",
+        "key": "Port",
+        "component": "Input",
+        "value": "18963",
+        "options": []
+      }
+    ],
     "disabled": false,
     "install": false,
     "installed": false


### PR DESCRIPTION
## Summary

新增 GFC 插件 `plugin-share-config-qrcode`，通过 QR 码将完整 Mihomo 配置分享到手机端 CMFA (Clash Meta for Android)。

### 功能
- 选择 Profile 后自动生成适配手机端的完整 Mihomo 配置
- 局域网内启动临时 HTTP 服务，生成 QR 码供手机扫码导入
- 自动适配处理：
  - 启用 TUN 模式
  - 内联 proxy-providers，消除重名冲突
  - 本地 rule-providers 转远程 HTTP
  - 补全 GLOBAL 代理组确保 CMFA 可见
  - 设置 proxy-server-nameserver / default-nameserver 避免 DNS 循环依赖
  - 支持链式代理 (dialer-proxy)、自定义代理组等完整配置透传

### 文件变更
- `plugins/GFC/plugin-share-config-qrcode.js` — 插件主文件
- `plugins/gfc.json` — 追加插件清单条目

### 仓库
https://github.com/KkemChen/plugin-share-config-qrcode

🤖 Generated with [Claude Code](https://claude.ai/claude-code)