### PR TITLE
fix: update plugin-share-config-qrcode to v1.1.0

### DIFF
--- a/plugins/GFC/plugin-share-config-qrcode.js
+++ b/plugins/GFC/plugin-share-config-qrcode.js
@@ -21,23 +21,26 @@ const onRun = async () => {
     )
   }
 
+  if (!profile) return
   await share(Plugins.deepClone(profile))
 }
 
 const share = async (profile) => {
   const port = Plugin.Port && Plugin.Port !== 'undefined' && Plugin.Port !== '' ? Plugin.Port : '18963'
 
-  // 1. 启用 TUN（手机端必须）
-  profile.tunConfig.enable = true
-  profile.tunConfig.stack = 'Mixed'
-  profile.tunConfig['auto-route'] = true
-  profile.tunConfig['auto-detect-interface'] = true
-  profile.tunConfig['dns-hijack'] = ['any:53']
-  profile.tunConfig['strict-route'] = true
+  // 1. 条件继承 TUN：PC 端已启用则补全手机端必要字段，否则原样保留
+  //    未启用 TUN 时 CMFA 通过 Android VPN Service 按钮控制流量，无需干预
+  if (profile.tunConfig?.enable) {
+    profile.tunConfig.stack = 'mixed'
+    profile.tunConfig['auto-route'] = true
+    profile.tunConfig['auto-detect-interface'] = true
+    profile.tunConfig['dns-hijack'] = profile.tunConfig['dns-hijack']?.length ? profile.tunConfig['dns-hijack'] : ['any:53']
+    profile.tunConfig['strict-route'] = true
+  }
 
   // 2. 替换本地规则集为远程规则集
   const rulesetsStore = Plugins.useRulesetsStore()
-  for (const rule of profile.rulesConfig) {
+  for (const rule of profile.rulesConfig || []) {
     if (rule.type !== 'RULE-SET' || !rule.enable) continue
     if (rule['ruleset-type'] === 'file' && rule.payload) {
       const ruleset = rulesetsStore.getRulesetById(rule.payload)
@@ -55,22 +58,23 @@ const share = async (profile) => {
   const config = await Plugins.generateConfig(profile)
 
   // 4. 消除 proxy-providers：全部内联节点，展开 use 引用
-  //    避免 http provider 与 inline proxies 重名冲突，确保配置完全自包含
+  //    展开失败时：有 URL 则降级为 http 类型保留，无 URL 则报错要求先更新订阅
   const subscribesStore = Plugins.useSubscribesStore()
   if (config['proxy-providers']) {
     const existingNames = new Set((config.proxies || []).map((p) => p.name))
+    const failedProviders = []
 
     for (const [id, provider] of Object.entries(config['proxy-providers'])) {
-      // 读取该 provider 的节点列表
       const sub = subscribesStore.getSubscribeById(id)
       const subPath = sub ? sub.path : provider.path?.replace(/^\.\.\//, 'data/')
       let providerProxyNames = []
+      let inlined = false
+
       if (subPath) {
         try {
           const content = await Plugins.ReadFile(subPath)
           const parsed = Plugins.YAML.parse(content)
           const proxies = parsed.proxies || []
-          // 内联不重复的节点
           for (const proxy of proxies) {
             if (!existingNames.has(proxy.name)) {
               config.proxies = config.proxies || []
@@ -79,23 +83,37 @@ const share = async (profile) => {
             }
           }
           providerProxyNames = proxies.map((p) => p.name)
+          inlined = true
         } catch (e) {
           console.warn(`无法读取订阅 ${id} 的缓存:`, e)
         }
       }
 
-      // 将引用此 provider 的 proxy-groups 的 use 展开为 proxies
-      for (const group of config['proxy-groups'] || []) {
-        if (group.use && group.use.includes(id)) {
-          group.use = group.use.filter((u) => u !== id)
-          if (group.use.length === 0) delete group.use
-          group.proxies = group.proxies || []
-          group.proxies.push(...providerProxyNames.filter((n) => !group.proxies.includes(n)))
+      if (inlined) {
+        delete config['proxy-providers'][id]
+        for (const group of config['proxy-groups'] || []) {
+          if (group.use && group.use.includes(id)) {
+            group.use = group.use.filter((u) => u !== id)
+            if (group.use.length === 0) delete group.use
+            group.proxies = group.proxies || []
+            group.proxies.push(...providerProxyNames.filter((n) => !group.proxies.includes(n)))
+          }
         }
+      } else if (provider.url) {
+        const { path: _path, ...rest } = provider
+        config['proxy-providers'][id] = { ...rest, type: 'http' }
+      } else {
+        failedProviders.push(id)
       }
     }
 
-    delete config['proxy-providers']
+    if (failedProviders.length > 0) {
+      throw `以下订阅没有缓存也没有远程 URL，无法导出到手机端：${failedProviders.join(', ')}。请先更新订阅后重试。`
+    }
+
+    if (Object.keys(config['proxy-providers']).length === 0) {
+      delete config['proxy-providers']
+    }
   }
 
   // 5. 兜底：检查 rule-providers 中残留的 file 类型
@@ -112,7 +130,7 @@ const share = async (profile) => {
     }
   }
 
-  // 7. CMFA 只显示 GLOBAL 组引用的代理组，确保自定义组可见
+  // 6. CMFA 只显示 GLOBAL 组引用的代理组，确保自定义组可见
   const groups = config['proxy-groups'] || []
   const globalGroup = groups.find((g) => g.name === 'GLOBAL')
   if (globalGroup) {
@@ -126,30 +144,47 @@ const share = async (profile) => {
     }
   }
 
-  // 8. 清理 PC 专属配置
+  // 7. 清理 PC 专属配置
   delete config.secret
   config['external-controller'] = '127.0.0.1:9090'
   config['allow-lan'] = false
 
-  // 9. TUN 模式 DNS 引导：确保代理节点域名和 DNS 服务器域名能直连解析，避免循环依赖
-  if (config.dns) {
-    const bootstrapDNS = ['223.5.5.5', '8.8.8.8']
-    if (!config.dns['proxy-server-nameserver'] || config.dns['proxy-server-nameserver'].length === 0) {
-      config.dns['proxy-server-nameserver'] = bootstrapDNS
+  // 8. DNS 适配
+  //    a) 只要 DNS 启用，无论是否 TUN，都必须保证 proxy-server-nameserver 存在
+  //       否则 Mihomo 用 DoT/DoH 解析代理节点域名时会经过代理路由，形成死循环
+  if (config.dns?.enable) {
+    if (!config.dns['proxy-server-nameserver']?.length) {
+      config.dns['proxy-server-nameserver'] = ['223.5.5.5', '119.29.29.29']
     }
-    if (!config.dns['default-nameserver'] || config.dns['default-nameserver'].length === 0) {
-      config.dns['default-nameserver'] = bootstrapDNS
+  }
+  //    b) TUN 模式额外要求：强制启用 DNS 并补全所有 bootstrap 字段
+  if (profile.tunConfig?.enable) {
+    config.dns = config.dns || {}
+    config.dns.enable = true
+    if (!config.dns['default-nameserver']?.length) {
+      config.dns['default-nameserver'] = ['223.5.5.5', '119.29.29.29']
+    }
+    if (!config.dns['proxy-server-nameserver']?.length) {
+      config.dns['proxy-server-nameserver'] = ['223.5.5.5', '119.29.29.29']
+    }
+    if (!config.dns.nameserver?.length) {
+      config.dns.nameserver = ['https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query']
     }
   }
 
-  // 8. 获取本机局域网 IP 并启动 HTTP 服务
-  const ips = await getIPAddress()
-  if (ips.length === 0) throw '未找到局域网 IP 地址，请检查网络连接'
+  // 9. 最终校验：拒绝导出仍含 file 类型的 rule-providers
+  const residualFileProviders = Object.entries(config['rule-providers'] || {})
+    .filter(([, rp]) => rp.type === 'file')
+    .map(([name]) => name)
+  if (residualFileProviders.length > 0) {
+    throw `以下 rule-providers 仍为本地文件类型，手机端无法访问：${residualFileProviders.join(', ')}。请将其配置为 http 类型后重试。`
+  }
 
   const configYaml = Plugins.YAML.stringify(config)
 
-  // DEBUG: 保存生成的配置供检查（调试时取消注释）
-  // await Plugins.WriteFile(PATH + '/debug-config.yaml', configYaml)
+  // 10. 获取本机局域网 IP 并启动 HTTP 服务
+  const ips = await getIPAddress()
+  if (ips.length === 0) throw '未找到局域网 IP 地址，请检查网络连接'
 
   const urls = await Promise.all(
     ips.map((ip) => {
@@ -158,34 +193,42 @@ const share = async (profile) => {
     })
   )
 
-  const { close } = await Plugins.StartServer('0.0.0.0:' + port, Plugin.id, async (req, res) => {
-    res.end(200, { 'Content-Type': 'text/yaml; charset=utf-8' }, configYaml)
-  })
+  let close
+  try {
+    ;({ close } = await Plugins.StartServer('0.0.0.0:' + port, Plugin.id, async (req, res) => {
+      res.end(200, { 'Content-Type': 'text/yaml; charset=utf-8' }, configYaml)
+    }))
+  } catch {
+    throw `端口 ${port} 启动失败，可能已被占用。请修改插件端口配置后重试。`
+  }
 
-  await Plugins.alert(
-    Plugin.name,
-    '### 注意事项：\n\n' +
-      ' - 请保证电脑和手机处于同一局域网内\n' +
-      ' - 请关闭电脑防火墙或放行端口 ' +
-      port +
-      '\n' +
-      ' - 如果 CMFA 无法通过深度链接导入，请复制链接在 CMFA 中手动添加\n' +
-      ' - 如果仍无法导入，请更换不同二维码尝试\n\n' +
-      '|分享链接|二维码|\n|-|-|\n' +
-      urls.map((item) => `|${item.url}|![](${item.qrcode})|`).join('\n'),
-    { type: 'markdown' }
-  )
-
-  close()
+  try {
+    await Plugins.alert(
+      Plugin.name,
+      '### 注意事项：\n\n' +
+        ' - 请保证电脑和手机处于同一局域网内\n' +
+        ' - 请关闭电脑防火墙或放行端口 ' +
+        port +
+        '\n' +
+        ' - 扫描二维码后，若 CMFA 未自动导入，请复制链接手动添加\n' +
+        ' - 如果仍无法导入，请更换不同二维码尝试\n\n' +
+        '|分享链接|二维码|\n|-|-|\n' +
+        urls.map((item) => `|${item.url}|![](${item.qrcode})|`).join('\n'),
+      { type: 'markdown' }
+    )
+  } finally {
+    close()
+  }
 }
 
 /**
  * 生成二维码 Data URL
  */
 function getQRCode(rawUrl, content) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     QRCode.toDataURL(content, { width: 256, margin: 2 }, (err, dataUrl) => {
-      resolve({ url: rawUrl, qrcode: dataUrl })
+      if (err) reject(err)
+      else resolve({ url: rawUrl, qrcode: dataUrl })
     })
   })
 }
@@ -199,7 +242,7 @@ function isPrivateIP(ip) {
   const first = parseInt(parts[0], 10)
   const second = parseInt(parts[1], 10)
   const fourth = parseInt(parts[3], 10)
-  if (first === 255 || fourth === 1 || fourth === 255) return false
+  if (first === 255 || fourth === 255) return false
   if (first === 10) return true
   if (first === 172 && second >= 16 && second <= 31) return true
   if (first === 192 && second === 168) return true
@@ -213,6 +256,7 @@ async function getIPAddress() {
   const os = Plugins.useEnvStore().env.os
   const cmd = { windows: 'ipconfig', linux: 'ip', darwin: 'ifconfig' }[os]
   const arg = { windows: [], linux: ['a'], darwin: [] }[os]
+  if (!cmd) throw `不支持的操作系统 "${os}"，无法自动获取局域网 IP`
   const text = await Plugins.Exec(cmd, arg, { convert: os === 'windows' })
   const ipv4Pattern = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g
   let ips = text.match(ipv4Pattern) || []

--- a/plugins/gfc.json
+++ b/plugins/gfc.json
@@ -54,8 +54,8 @@
   {
     "id": "plugin-share-config-qrcode",
     "name": "扫码分享配置到手机CMFA",
-    "version": "v1.0.0",
-    "description": "手机端CMFA(Clash Meta for Android)扫码即可一键导入完整Mihomo配置。电脑端启动局域网临时HTTP服务，自动完成手机适配：启用TUN模式、内联proxy-providers消除重名冲突、本地rule-providers转远程HTTP、补全GLOBAL代理组确保CMFA可见、设置proxy-server-nameserver避免DNS循环依赖。支持链式代理(dialer-proxy)、自定义代理组等完整配置透传。Supported by: KkemChen",
+    "version": "v1.1.0",
+    "description": "手机端CMFA(Clash Meta for Android)扫码即可一键导入完整Mihomo配置。电脑端启动局域网临时HTTP服务，自动完成手机适配：条件继承TUN模式（PC端启用才补全，未启用则不干预）、内联proxy-providers消除重名冲突（失败时降级http或报错）、本地rule-providers转远程HTTP并最终校验、补全GLOBAL代理组确保CMFA可见、智能DNS适配（DNS启用时保证proxy-server-nameserver防循环依赖，TUN启用时补全所有bootstrap字段）。支持链式代理(dialer-proxy)、自定义代理组等完整配置透传。Supported by: KkemChen",
     "tags": ["实用工具", "功能扩展", "提升体验"],
     "type": "Http",
     "url": "https://raw.githubusercontent.com/GUI-for-Cores/Plugin-Hub/main/plugins/GFC/plugin-share-config-qrcode.js",


### PR DESCRIPTION
## Summary

- **TUN 条件继承**：不再无条件强制启用 TUN，改为仅当 PC 端已启用时补全手机端必要字段；未启用时不干预，CMFA 通过 Android VPN Service 按钮控制流量
- **DNS 智能适配**：只要 DNS 启用就保证 `proxy-server-nameserver` 存在（防止 DoT/DoH 解析代理节点域名时经过代理路由形成死循环）；TUN 启用时额外补全所有 bootstrap 字段
- **proxy-providers 按粒度展开**：逐个 provider 跟踪展开状态，失败时降级为 http 类型（若有 URL）或明确报错（无缓存无 URL），不再无条件删除
- **rule-providers 最终校验**：导出前检查是否还有 `type: file` 的 rule-provider，有则拒绝导出并列出具体名称
- **健壮性修复**：tunConfig/rulesConfig 空值防护、picker 取消保护、端口冲突处理、Server 生命周期 try/finally、QR 码生成错误处理、isPrivateIP 修正、未知 OS 友好报错

## Test plan

- [ ] PC 端 TUN 开 + DNS 开：手机端 TUN 补全 + DNS 全补，测速正常
- [ ] PC 端 TUN 关 + DNS 开：手机端不强加 TUN，只补 proxy-server-nameserver，测速正常
- [ ] PC 端 TUN 开 + DNS 关：手机端 TUN 补全 + 创建 DNS 段并全补，测速正常
- [ ] PC 端 TUN 关 + DNS 关：手机端原样继承，不动 DNS/TUN
- [ ] 订阅未更新（无缓存）但有 URL 时：降级为 http 类型 provider
- [ ] 存在无法转换的 file 类型 rule-provider 时：拒绝导出并提示
- [ ] 端口被占用时：友好提示而非崩溃

🤖 Generated with [Claude Code](https://claude.com/claude-code)