### PR TITLE
Fix smart proxy switcher delay endpoint

### DIFF
--- a/plugins/Generic/plugin-smart-proxy-switcher.js
+++ b/plugins/Generic/plugin-smart-proxy-switcher.js
@@ -45,9 +45,12 @@ export default (Plugin) => {
         return
       }
       const proxies = kernelApi.proxies[group].all.map((proxy) => {
+        const provider = kernelApi.proxies[proxy]?.provider
         return {
           id: proxy,
-          url: `/proxies/${encodeURIComponent(proxy)}/delay`,
+          url: provider
+            ? `/providers/proxies/${encodeURIComponent(provider)}/${encodeURIComponent(proxy)}/healthcheck`
+            : `/proxies/${encodeURIComponent(proxy)}/delay`,
           priority: 1, // 节点权重暂未使用，全设置为1
           group
         }

--- a/plugins/generic.json
+++ b/plugins/generic.json
@@ -562,7 +562,7 @@
   },
   {
     "id": "plugin-smart-proxy-switcher",
-    "version": "v5.2.1",
+    "version": "v5.2.2",
     "name": "节点智能切换",
     "group": "Extensions",
     "description": "实现动态代理选择机制，包含故障转移、断路器、EWMA 延迟跟踪、基于分数调度与滞后控制。",


### PR DESCRIPTION
## What changed

- Route provider-backed proxies through `/providers/proxies/{provider}/{proxy}/healthcheck`.
- Keep `/proxies/{proxy}/delay` for proxies without a provider.
- Bump `plugin-smart-proxy-switcher` from `v5.2.1` to `v5.2.2`.

## Why

Recent stable Clash cores require the provider healthcheck endpoint for provider-backed nodes. The plugin used the generic proxy delay endpoint for every node, causing provider latency checks to fail and preventing reliable automatic switching. This matches the compatibility change in `GUI-for-Cores/GUI.for.Clash@af389c1`.

## Impact

Latency monitoring and automatic node selection work again for provider-backed proxies while preserving the existing behavior for built-in proxies.

## Validation

- `node --check plugins/Generic/plugin-smart-proxy-switcher.js`
- Parsed `plugins/generic.json` with Node.js
- `pnpm exec prettier --check plugins/Generic/plugin-smart-proxy-switcher.js plugins/generic.json`
- `git diff --check`