### PR TITLE
Fix message bubble display issue for plugin-gui-agent

### DIFF
--- a/plugins/Generic/plugin-gui-agent.js
+++ b/plugins/Generic/plugin-gui-agent.js
@@ -312,7 +312,7 @@ export default (Plugin) => {
             </Card>
           </div>
         </div>
-        <div v-for="(item, index) in chatHistory" :key="index" class="text-14 break-all leading-relaxed">
+        <div v-for="(item, index) in chatHistory" :key="index" class="gui-agent-message text-14 break-all leading-relaxed" :class="'gui-agent-message--' + item.role">
           <div v-if="item.compressed" class="flex justify-center my-8">
             <details class="text-12 w-full" style="color: var(--card-color)">
               <summary class="flex items-center justify-center cursor-pointer">
@@ -327,7 +327,7 @@ export default (Plugin) => {
             </details>
           </div>
           <div v-else-if="item.role == 'user'" class="flex items-center justify-end mb-8">
-            <div class="ml-24 rounded-8 px-8 py-4" style="background: var(--card-bg)">{{ item.content }}</div>
+            <div class="gui-agent-message__bubble ml-24 rounded-8 px-8 py-4" style="background: var(--gui-agent-user-message-bg, var(--card-bg))">{{ item.content }}</div>
             <Dropdown placement="bottom">
               <Button icon="more" type="text" />
               <template #overlay="{ close }">
@@ -338,7 +338,7 @@ export default (Plugin) => {
               </template>
             </Dropdown>
           </div>
-          <div v-else-if="item.role == 'assistant' && (item.content || item.tool_calls || item.images)">
+          <div v-else-if="item.role == 'assistant' && (item.content || item.tool_calls || item.images)" class="gui-agent-message__assistant">
             <MarkdownViewer v-if="item.content" :content="item.content" />
             <div v-if="item.images?.length" class="flex flex-col gap-8 my-8">
               <StoredImage v-for="image in item.images" :key="image.path" :path="image.path" :mime="image.type" />

--- a/plugins/Resources/plugin-skin-manager/neon-tianyi/neon-tianyi.css
+++ b/plugins/Resources/plugin-skin-manager/neon-tianyi/neon-tianyi.css
@@ -565,6 +565,17 @@ body.skin-theme .gui-modal-modal {
   backdrop-filter: none;
 }
 
+body.skin-theme .gui-agent-message--user .gui-agent-message__bubble {
+  --gui-agent-user-message-bg: linear-gradient(135deg, rgba(14, 68, 82, 0.96), rgba(18, 42, 74, 0.96));
+  border: 1px solid rgba(97, 216, 232, 0.42);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.16);
+}
+
+body.skin-theme .gui-agent-message--assistant .gui-agent-message__assistant {
+  padding-left: 10px;
+  border-left: 2px solid rgba(154, 139, 237, 0.58);
+}
+
 body.skin-theme .gui-tag {
   color: #bfecef;
   border-color: rgba(97, 216, 232, 0.22);


### PR DESCRIPTION
agent 的用户消息固定使用 `background: var(--card-bg)`，而 agent 回复没有消息气泡，直接透明地显示在内容区
导致用户的话和 agent 的回答区分并不明显，除了复古QQ皮肤有一定区分度，其他的包括深/浅色的默认主题和其余皮肤均存在不同程度的该问题

### 改动

在 gui-agent 给用户气泡和 agent 回复补充稳定类名，`.gui-agent-message--<role>`， `.gui-agent-message--user` 和 `.gui-agent-message--assistant`

用户消息背景改为读取 `--gui-agent-user-message-bg`，未定义时回退到原来的 `--card-bg`，未适配该变量的默认主题和其他皮肤保持原有外观，皮肤可按消息角色提供专属样式

本次**只改动了我的霓城天依皮肤**，用户消息显示为青蓝气泡，agent 回复增加紫色左侧标记，**没有改变其他主题和皮肤的视觉表现**

### 效果（前/后）
<img width="800" height="210" alt="compare" src="https://github.com/user-attachments/assets/b549aaa5-b674-4b23-ae7b-a7ca5a0177ae" />

### 其他皮肤的情况
<img width="800" height="218" alt="other" src="https://github.com/user-attachments/assets/6c52acd6-a105-4ffa-99ce-f6488920dea7" />
