### PR TITLE
Fix the issue with scaling of miku skin

### DIFF
--- a/plugins/Resources/plugin-skin-manager/miku/miku.css
+++ b/plugins/Resources/plugin-skin-manager/miku/miku.css
@@ -335,12 +335,20 @@ body.skin-theme .traffic-panel__art {
     linear-gradient(90deg, rgba(247, 249, 255, 0.82) 0%, rgba(247, 249, 255, 0.18) 38%, rgba(245, 226, 255, 0.03) 100%), var(--skin-manager-background);
   background-position:
     center,
-    58% bottom;
+    83% 69%;
   background-size:
     cover,
-    auto 128%;
+    cover;
   filter: saturate(1.02) brightness(1.03);
   mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0.54), #000 34%, #000);
+}
+
+@media (max-width: 900px) {
+  body.skin-theme .traffic-panel__art {
+    background-position:
+      center,
+      79% 69%;
+  }
 }
 
 body.skin-theme .mode-panel {


### PR DESCRIPTION
miku 皮肤之前的缩放策略是 `auto 128%/130%/132%`，虽然能保持比例，但不能保证覆盖宽而浅的流量区，窗口变宽时可能露出底层

实际上 doraemon、cream-moon、nangong-wan 皮肤也有这个问题，但是没想到合适的方案，所以只修复了 miku 皮肤的问题

### 改动

使用多层背景，`cover` 保持比例并完整覆盖，默认取景锚点为右侧 miku 的 83% 69%，900px 以下回调至 79% 69%，避免缩窄时过度裁掉人物

### 效果（前/后）

<img width="800" height="697" alt="output" src="https://github.com/user-attachments/assets/9e61c7b6-50e2-487e-bb61-d6eda6695e10" />
